### PR TITLE
Avoid permission issues when renewing under cron

### DIFF
--- a/root/usr/local/bin/lexicon-hook
+++ b/root/usr/local/bin/lexicon-hook
@@ -13,7 +13,7 @@ function deploy_challenge {
 
     echo "deploy_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
 
-    lexicon $PROVIDER create ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
+    lexicon --config-dir=/data $PROVIDER create ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
 
     sleep 30
 
@@ -40,7 +40,7 @@ function clean_challenge {
 
     echo "clean_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
 
-    lexicon $PROVIDER delete ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
+    lexicon --config-dir=/data $PROVIDER delete ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
 
     # This hook is called after attempting to validate each domain,
     # whether or not validation was successful. Here you can delete


### PR DESCRIPTION
Dehydrated is kicked off by the root user's crontab and so with a current working directory of /root. It then su-exec's to the UID/GID provided in the environment. Without specifying a config-dir lexicon uses the current working directory. As not-root it doesn't have permissions to look for YAML files in /root.

Specify an accessible directory to use as the config directory. We're not expecting to find YAML files there, we just need it to be readable by UID/GID. By using `/data` it is possible for us to provide YAML files if we so desire